### PR TITLE
fix failing tests

### DIFF
--- a/Serializer/Handler/DateHandler.php
+++ b/Serializer/Handler/DateHandler.php
@@ -53,7 +53,7 @@ class DateHandler implements SubscribingHandlerInterface
         return $methods;
     }
 
-    public function __construct($defaultFormat = \DateTime::ISO8601, $defaultTimezone = 'UTC', $xmlCData = true)
+    public function __construct($defaultFormat = 'Y-m-d\TH:i:s.uP', $defaultTimezone = 'UTC', $xmlCData = true)
     {
         $this->defaultFormat = $defaultFormat;
         $this->defaultTimezone = new \DateTimeZone($defaultTimezone);


### PR DESCRIPTION
Update default date format in DateHandler in Serializer.
ISO8601 was missing milliseconds and causing a serialisation problem specific to php 7.1+.
Please review.
Mel